### PR TITLE
fix the generation of the service token

### DIFF
--- a/qwanda-service-war/.externalToolBuilders/org.jboss.tools.jst.web.kb.kbbuilder.launch
+++ b/qwanda-service-war/.externalToolBuilders/org.jboss.tools.jst.web.kb.kbbuilder.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
+<stringAttribute key="org.eclipse.ui.externaltools.ATTR_DISABLED_BUILDER" value="org.jboss.tools.jst.web.kb.kbbuilder"/>
+<mapAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS"/>
+<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
+</launchConfiguration>

--- a/qwanda-service-war/META-INF/persistence.xml
+++ b/qwanda-service-war/META-INF/persistence.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+	<persistence-unit name="qwanda-service-war">
+	</persistence-unit>
+</persistence>

--- a/qwanda-service-war/src/main/java/life/genny/qwanda/endpoint/KeycloakEndpoint.java
+++ b/qwanda-service-war/src/main/java/life/genny/qwanda/endpoint/KeycloakEndpoint.java
@@ -121,7 +121,7 @@ public class KeycloakEndpoint {
 				JsonObject secretJson = realmJson.getJsonObject("credentials");
 				String secret = secretJson.getString("secret");
 				log.info("secret " + secret);
-				userToken = KeycloakUtils.getToken(registration.getKeycloakUrl(), realm, realm, secret, registration.getUsername(), registration.getPassword());
+				userToken = KeycloakUtils.getAccessToken(registration.getKeycloakUrl(), realm, realm, secret, registration.getUsername(), registration.getPassword());
 				log.info("User token = "+userToken);
 			} catch (IOException e) {
 				return Response.status(400).entity("could not obtain access token").build();

--- a/qwanda-service-war/src/main/java/life/genny/qwanda/endpoint/UtilsEndpoint.java
+++ b/qwanda-service-war/src/main/java/life/genny/qwanda/endpoint/UtilsEndpoint.java
@@ -160,7 +160,7 @@ public class UtilsEndpoint {
 				JsonObject keycloakJson  = new JsonObject(keycloakJsonText);
 				String keycloakUrl = keycloakJson.getString("auth-server-url");
 				String secret = keycloakJson.getJsonObject("credentials").getString("secret");
-				String token = KeycloakUtils.getToken(keycloakUrl, realm, realm,
+				String token = KeycloakUtils.getAccessToken(keycloakUrl, realm, realm,
 						secret, "service", service_password);
 				log.info("token = "+token);
 				QwandaUtils.apiPostEntity(GennySettings.vertxUrl, json.toString(), token);

--- a/qwanda-service-war/src/main/java/life/genny/qwanda/service/KeycloakService.java
+++ b/qwanda-service-war/src/main/java/life/genny/qwanda/service/KeycloakService.java
@@ -100,7 +100,7 @@ public class KeycloakService {
         formParams.add(new BasicNameValuePair(OAuth2Constants.CLIENT_SECRET, secret));
       }
       final UrlEncodedFormEntity form = new UrlEncodedFormEntity(formParams, "UTF-8");
-
+      
       post.setEntity(form);
 
       final HttpResponse response = httpClient.execute(post);

--- a/qwanda-service-war/src/main/java/life/genny/qwanda/service/Service.java
+++ b/qwanda-service-war/src/main/java/life/genny/qwanda/service/Service.java
@@ -394,7 +394,7 @@ public class Service extends BaseEntityService2 {
 	public  String getServiceToken(String realm) {
 
 		/* we get the service token currently stored in the cache */
-		String serviceToken = VertxUtils.getObject(realm, "CACHE", "SERVICE_TOKEN", String.class);
+		String serviceToken = this.readFromDDT("CACHE:SERVICE_TOKEN");
 
 		/* if we have got a service token cached */
 		if (serviceToken != null) {

--- a/qwanda-service-war/src/main/java/life/genny/qwanda/service/Service.java
+++ b/qwanda-service-war/src/main/java/life/genny/qwanda/service/Service.java
@@ -412,9 +412,11 @@ public class Service extends BaseEntityService2 {
 			long duration = expiryTime - nowTime;
 
 			/* if the difference is negative it means the expiry time is less than the nowTime 
-				 if the difference < 180000, it means the token will expire in 3 hours
+				 if the difference < ACCESS_TOKEN_EXPIRY_LIMIT_SECONDS, it means the token will expire in 3 hours
 			*/
-			if(duration >= 10800) {
+			if(duration > GennySettings.ACCESS_TOKEN_EXPIRY_LIMIT_SECONDS) {
+
+				System.out.println("======= USING CACHED ACCESS TOKEN ========");
 
 				/* if the token is NOTn about to expire (> 3 hours), we reuse it */
 				return serviceToken;

--- a/qwanda-service-war/src/main/java/life/genny/qwanda/service/Service.java
+++ b/qwanda-service-war/src/main/java/life/genny/qwanda/service/Service.java
@@ -422,7 +422,7 @@ public class Service extends BaseEntityService2 {
 					+ "keycloakurl: " + keycloakurl + "\n" + "key : " + key + "\n" + "initVector : " + initVector + "\n"
 					+ "enc pw : " + encryptedPassword + "\n" + "password : " + password + "\n");
 
-			String token = KeycloakUtils.getToken(keycloakurl, realm, realm, secret, "service", password);
+			String token = KeycloakUtils.getAccessToken(keycloakurl, realm, realm, secret, "service", password);
 			log.info("token = " + token);
 			return token;
 

--- a/qwanda-service-war/src/main/webapp/META-INF/persistence.xml
+++ b/qwanda-service-war/src/main/webapp/META-INF/persistence.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+	<persistence-unit name="qwanda-service-war">
+	</persistence-unit>
+</persistence>


### PR DESCRIPTION
Issue: https://outcomelife.atlassian.net/browse/GEN-1391

### Bug Description:

It looks like the service token was grabbed from the cache before. This was to prevent having to create a new session every time, but it is actually creating lots of issues as the service token is not refreshed when it needs to be. This is a rollback to creating a new session every time for now.

### How To Test:

On internmatch, try to create a new internship. Most of the dropdowns with multiple selections will be empty. that's because the backend rules use the SearchEntity to get the relevant data using the service token. because the service token has expired, no data is showing in the dropdown.

### Dependency: 

https://github.com/genny-project/genny-verticle-rules/pull/4